### PR TITLE
Fix processing with newer verisons of mtr

### DIFF
--- a/mtr.go
+++ b/mtr.go
@@ -158,7 +158,7 @@ func NewMTROutPut(raw, target string, count int) (*MTROutPut, error) {
 	//Store each line of output in rawhop structure
 	for _, line := range strings.Split(raw, "\n") {
 		things := strings.Split(line, " ")
-		if len(things) == 3 {
+		if len(things) == 3 || (len(things) == 4 && things[0] == "p") {
 			//log.Println(things)
 			idx, err := strconv.Atoi(things[1])
 			if err != nil {


### PR DESCRIPTION
Annoyingly, "mtr" now has four fields for a 'p' line!

This fixes your code so that it works with v0.87, it was working until v0.86!
